### PR TITLE
fix(analytics): resolve 4 GTM/GA4 tracking bugs

### DIFF
--- a/src/components/FilterDropDown.tsx
+++ b/src/components/FilterDropDown.tsx
@@ -17,6 +17,7 @@ import { Button } from "./ui/button";
 
 import styles from "../components/scss/FilterDropDown.module.scss";
 import { useFilter } from "../context/FilterContext";
+import { gaEvent } from "@/lib/ga";
 
 type FilterGroupProps = {
   title: string;
@@ -119,6 +120,22 @@ const FilterDropDown: React.FC<{
     });
   };
   const applyFilters = () => {
+    if (tempFilterValueList.length > 0) {
+      const getFilterType = (value: string): string => {
+        if (AllCompanies.includes(value)) return "company";
+        if (AllCategories.includes(value)) return "category";
+        if (AllTextures.includes(value)) return "texture";
+        if (AllColors.includes(value)) return "color";
+        if (AllSizes.includes(value)) return "size";
+        return "unknown";
+      };
+      const filterTypes = [...new Set(tempFilterValueList.map(getFilterType))];
+      gaEvent("filter_applied", {
+        filter_values: tempFilterValueList.join(", "),
+        filter_count: tempFilterValueList.length,
+        filter_types: filterTypes.join(", "),
+      });
+    }
     setFilterValueList(tempFilterValueList);
   };
   const filterCountsArray = [

--- a/src/components/ProductFilters.tsx
+++ b/src/components/ProductFilters.tsx
@@ -17,6 +17,7 @@ import {
 import styles from "./scss/MaterialFilters.module.scss";
 import { useState } from "react";
 import { useFilter } from "../context/FilterContext";
+import { gaEvent } from "@/lib/ga";
 import { Button } from "./ui/button";
 
 type FilterGroupProps = {
@@ -116,6 +117,22 @@ export const ProductFilters: React.FC<{
   };
 
   const applyFilters = () => {
+    if (tempFilterValueList.length > 0) {
+      const getFilterType = (value: string): string => {
+        if (AllCompanies.includes(value)) return "company";
+        if (AllCategories.includes(value)) return "category";
+        if (AllTextures.includes(value)) return "texture";
+        if (AllColors.includes(value)) return "color";
+        if (AllSizes.includes(value)) return "size";
+        return "unknown";
+      };
+      const filterTypes = [...new Set(tempFilterValueList.map(getFilterType))];
+      gaEvent("filter_applied", {
+        filter_values: tempFilterValueList.join(", "),
+        filter_count: tempFilterValueList.length,
+        filter_types: filterTypes.join(", "),
+      });
+    }
     setFilterValueList(tempFilterValueList);
   };
   return (

--- a/src/components/sections/materialDetailPage/MaterialDetailForm.tsx
+++ b/src/components/sections/materialDetailPage/MaterialDetailForm.tsx
@@ -97,7 +97,9 @@ export default function MaterialDetailForm({ product }: FormProps) {
     gaEvent("add_to_cart", {
       items: [
         {
+          item_id: product.id,
           item_name: values.name,
+          item_brand: product.company.join(", "),
           item_category: values.category || undefined,
           item_variant: values.size || undefined,
           quantity: parseInt(values.quantity, 10),

--- a/src/components/sections/materialDetailPage/MaterialDetailPageClient.tsx
+++ b/src/components/sections/materialDetailPage/MaterialDetailPageClient.tsx
@@ -53,7 +53,7 @@ export default function MaterialDetailPageClient({
           item_id: product.id,
           item_name: product.name,
           item_category: product.categories?.map((cat) => cat.name).join(", "),
-          item_company: product.company.join(", "),
+          item_brand: product.company.join(", "),
         },
       ],
     });
@@ -189,9 +189,15 @@ export default function MaterialDetailPageClient({
 
           <div className="flex gap-6">
             <Button
-              onClick={() =>
-                window.open("/Category_Sizes_Reference.pdf", "_blank")
-              }
+              onClick={() => {
+                gaEvent("file_download", {
+                  file_name: "Category_Sizes_Reference.pdf",
+                  file_extension: "pdf",
+                  link_text: "Category Sizes",
+                  link_url: "/Category_Sizes_Reference.pdf",
+                });
+                window.open("/Category_Sizes_Reference.pdf", "_blank");
+              }}
             >
               Category Sizes
             </Button>


### PR DESCRIPTION
- view_item: rename item_company → item_brand (GA4 ecommerce standard)
- add_to_cart: add item_id and item_brand so GA4 can join the funnel
- file_download: add gaEvent call before window.open on PDF button
- filter_applied: implement event in both ProductFilters and FilterDropDown; was documented but never wired up in either component